### PR TITLE
chore: fix for UnsupportedNodeClient case

### DIFF
--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -554,13 +554,13 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         &self,
         tx: &TypedTransaction,
         block: Option<BlockId>,
-        optimize_gas: Option<bool>
+        optimize_gas: Option<bool>,
     ) -> Result<AccessListWithGasUsed, ProviderError> {
         let tx = utils::serialize(tx);
         let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
         let optimize_gas = utils::serialize(&optimize_gas.unwrap_or_else(|| true));
-        let node_client = self.node_client().await?;
-        if let NodeClient::Erigon = node_client {
+        let node_client = self.node_client().await;
+        if let Ok(NodeClient::Erigon) = node_client {
             self.request("eth_createAccessList", [tx, block, optimize_gas]).await
         } else {
             self.request("eth_createAccessList", [tx, block]).await


### PR DESCRIPTION
## Motivation
Some nodes seem to be falling outside of the `NodeClient` supported list, returning an `UnsupportedNodeClient` error when the type of node is consulted, causing the updated `create_access_list` function to panic.

## Solution
Remove the unwrapping for `node_client` result and call the default "non Erigon" option for such cases.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
